### PR TITLE
Rename commands + mathtools patch

### DIFF
--- a/luamml-demo.sty
+++ b/luamml-demo.sty
@@ -27,7 +27,7 @@
 }
 \DeclareOption{structelem}{
   \bool_set_true:N \l__luamml_demo_structelem_bool
-  \luamml_flag_structelem:
+  \luamml_structelem:
 }
 \DeclareOption{files}{
   \int_new:N \g__luamml_demo_mathml_int

--- a/luamml-patches-amsmath.sty
+++ b/luamml-patches-amsmath.sty
@@ -42,7 +42,7 @@
           \m@th
           \displaystyle
           {##}
-          \luamml_flag_save:nNn {} \displaystyle {mtd}
+          \luamml_save:nNn {} \displaystyle {mtd}
         $
         \__luamml_amsmath_add_last_to_row:
         \tabskip \z@skip
@@ -54,7 +54,7 @@
             {}
             ##
           }
-          \luamml_flag_save:nNn {} \displaystyle {mtd}
+          \luamml_save:nNn {} \displaystyle {mtd}
         $
         \__luamml_amsmath_add_last_to_row:
         \hfil
@@ -85,7 +85,7 @@
           \m@th
           \displaystyle
           ##
-          \luamml_flag_save:nNn {} \displaystyle {mtd}
+          \luamml_save:nNn {} \displaystyle {mtd}
         $
         \__luamml_amsmath_add_last_to_row:
         \hfil
@@ -122,7 +122,7 @@
           \m@th
           \displaystyle
           {##}
-          \luamml_flag_save:nNn {} \displaystyle {mtd}
+          \luamml_save:nNn {} \displaystyle {mtd}
         $
       }
       \__luamml_amsmath_add_box_to_row:
@@ -153,7 +153,7 @@
 \cs_set:Npn \gmeasure@ #1 {
   \exp_last_unbraced:Nno
     \use_ii_i:nn
-    { \luamml_flag_ignore: }
+    { \luamml_ignore: }
     { \__luamml_amsmath_original_gmeasure:n {#1} }
 }
 
@@ -178,9 +178,9 @@
         \displaystyle
         {##}
         \ifmeasuring@
-          \luamml_flag_ignore:
+          \luamml_ignore:
         \else
-          \luamml_flag_save:nNn {} \displaystyle {mtd}
+          \luamml_save:nNn {} \displaystyle {mtd}
         \fi
       $
     }
@@ -202,9 +202,9 @@
         ##
       }
       \ifmeasuring@
-        \luamml_flag_ignore:
+        \luamml_ignore:
       \else
-        \luamml_flag_save:nNn {} \displaystyle {mtd}
+        \luamml_save:nNn {} \displaystyle {mtd}
       \fi
       $
     }
@@ -289,7 +289,7 @@
 \cs_set:Npn \mmeasure@ #1 {
   \exp_last_unbraced:Nno
     \use_ii_i:nn
-    { \luamml_flag_ignore: }
+    { \luamml_ignore: }
     { \__luamml_amsmath_original_mmeasure:n {#1} }
 }
 
@@ -298,14 +298,14 @@
 % Less luckily, \endmultline@math sometimes get overwritten for the last line.
 % But that isn't a problem since we want special behavior there anyway.
 \cs_set:Npn \endmultline@math {
-  \luamml_flag_save:nNn {} \displaystyle {mtd}
+  \luamml_save:nNn {} \displaystyle {mtd}
   $
   \__luamml_amsmath_add_last_to_row:
 }
 
 \cs_set:Npn \rendmultline@ {
     \iftag@
-      \luamml_flag_save:nNn {} \displaystyle {mtd}
+      \luamml_save:nNn {} \displaystyle {mtd}
       $
       \__luamml_amsmath_add_last_to_row:
       \let \endmultline@math \relax
@@ -370,7 +370,7 @@
         \m@th
         \scriptstyle
         ##
-        \luamml_flag_save:nn {} {mtd} % No \scriptsize here since we want to add the mstyle nodes
+        \luamml_save:nn {} {mtd} % No \scriptsize here since we want to add the mstyle nodes
         $
         \__luamml_amsmath_add_last_to_row:
         \hfil
@@ -381,7 +381,7 @@
         \m@th
         \scriptstyle
         ##
-        \luamml_flag_save:nn {} {mtd} % No \scriptsize here since we want to add the mstyle nodes
+        \luamml_save:nn {} {mtd} % No \scriptsize here since we want to add the mstyle nodes
         $
         \__luamml_amsmath_add_last_to_row:
         \hfil
@@ -404,7 +404,7 @@
   \let \@ifnextchar \new@ifnextchar
   \left \lbrace
     \def \arraystretch {1.2}
-    \array {@{}l@{\quad \luamml_flag_ignore:}l@{}}
+    \array {@{}l@{\quad \luamml_ignore:}l@{}}
 }
 
 

--- a/luamml-patches-array.sty
+++ b/luamml-patches-array.sty
@@ -18,7 +18,7 @@
       } {
         \__luamml_array_init_col:
         \insert@column
-        \luamml_flag_save:nn {} {mtd}
+        \luamml_save:nn {} {mtd}
         \d@llarend
         \__luamml_array_finalize_col:w 0~
       }
@@ -33,7 +33,7 @@
       } {
         \__luamml_array_init_col:
         \insert@column
-        \luamml_flag_save:nn {} {mtd}
+        \luamml_save:nn {} {mtd}
         \d@llarend
         \__luamml_array_finalize_col:w 1~
       }
@@ -49,7 +49,7 @@
       } {
         \__luamml_array_init_col:
         \insert@column
-        \luamml_flag_save:nn {} {mtd}
+        \luamml_save:nn {} {mtd}
         \d@llarend
         \__luamml_array_finalize_col:w 2~
       }

--- a/luamml-patches-kernel.sty
+++ b/luamml-patches-kernel.sty
@@ -7,7 +7,7 @@
     \m@th #1 {
       #2
     }
-    \luamml_flag_save:nNn {mathsmash} #1 {mpadded}
+    \luamml_save:nNn {mathsmash} #1 {mpadded}
     \luamml_pdf_write:
     $
   }
@@ -28,7 +28,7 @@
     \m@th
     #1
     {#2}
-    \luamml_flag_save:nNn {mathphant} #1 {mphantom}
+    \luamml_save:nNn {mathphant} #1 {mphantom}
     $
   }
   \luamml_annotate:nen {1} {

--- a/luamml-patches-mathtools.sty
+++ b/luamml-patches-mathtools.sty
@@ -1,0 +1,35 @@
+\ProvidesExplPackage {luamml-patches-mathtools} {2024-10-26} {0.1.0}
+  {Feel free to add a description here}
+
+\RequirePackage{luamml-patches-amsmath}
+% see https://github.com/latex3/tagging-project/issues/734
+\renewcommand*\MT_mult_internal:n [1]{
+ \MH_if_boolean:nF {outer_mult}{\alignedspace@left} %<-- requires amsmath 2016/11/05
+  \MT_next:
+  \bgroup
+    \Let@
+    \def\l_MT_multline_lastline_fint{0 }
+    \chardef\dspbrk@context\@ne \restore@math@cr
+    \MH_let:NwN \math@cr@@\MT_mult_mathcr_atat:w
+    \MH_let:NwN \shoveleft\MT_shoveleft:wn
+    \MH_let:NwN \shoveright\MT_shoveright:wn
+    \spread@equation
+    \MH_set_boolean_F:n {mult_firstline}
+    \MT_measure_mult:n {#1}
+    \MH_if_dim:w \l_MT_multwidth_dim<\l_MT_multline_measure_fdim
+      \MH_setlength:dn \l_MT_multwidth_dim{\l_MT_multline_measure_fdim}
+    \fi
+    \MH_set_boolean_T:n {mult_firstline}
+    \MH_if_num:w \l_MT_multline_lastline_fint=\@ne
+      \MH_let:NwN \math@cr@@ \MT_mult_firstandlast_mathcr:w
+    \MH_fi:
+    \ialign\bgroup
+      \hfil\strut@$\m@th\displaystyle{}##
+      \luamml_save:nNn {} \displaystyle {mtd}
+      $
+      \__luamml_amsmath_add_last_to_row:
+      \hfil
+      \crcr
+      \hfilneg
+      #1
+}

--- a/luamml.dtx
+++ b/luamml.dtx
@@ -540,6 +540,7 @@
 %<*luatex>
 \__luamml_patch_package:n {amstext}
 \__luamml_patch_package:n {amsmath}
+\__luamml_patch_package:n {mathtools}
 \__luamml_patch_package:n {array}
 %</luatex>
 %    \end{macrocode}

--- a/luamml.dtx
+++ b/luamml.dtx
@@ -170,16 +170,20 @@
 % The most important interface is for setting the flag which controls how the
 % formulas should be converted.
 %
-% \begin{macro}{\luamml_flag_process:}
+% \begin{macro}{\luamml_process:}
 %   Consider the current formula to be a complete, free-standing mathematical
 %   expression which should be converted to MathML. Additionally, the formula
 %   is also saved in the \texttt{start\_math} node as with
-%   \cs{luamml_flag_save:}.
+%   \cs{luamml_save:}.
 %    \begin{macrocode}
-\cs_new_protected:Npn \luamml_flag_process: {
+\cs_new_protected:Npn \luamml_process: {
   \tl_set:Nn \l__luamml_label_tl {}
   \int_set:Nn \l__luamml_flag_int { 3 }
 }
+%    \end{macrocode}
+% Temporarly for compatibility
+%    \begin{macrocode}
+\cs_set_eq:NN \luamml_flag_process: \luamml_process:
 %    \end{macrocode}
 % \end{macro}
 %
@@ -194,6 +198,7 @@
     } {2}
   ) +
 }
+%    \end{macrocode}
 % \end{macro}
 %
 % \begin{macro}{\__luamml_style_to_num:N}
@@ -215,61 +220,76 @@
 % \end{macro}
 %
 %
-% \begin{macro}{\luamml_flag_save:n,
-%               \luamml_flag_save:nN,
-%               \luamml_flag_save:nn,
-%               \luamml_flag_save:nNn}
+% \begin{macro}{\luamml_save:n,
+%               \luamml_save:nN,
+%               \luamml_save:nn,
+%               \luamml_save:nNn}
 %   Convert the current formula but only save it's representation in the math
 %   node without emitting it as a complete formula. This is useful when the
-%   expression forms part of a bigger formula and will be intergrated into it's
+%   expression forms part of a bigger formula and will be integrated into it's
 %   MathML tables later by special code.
-%   It optinally accepts three parameters: A label, one math style command
+%   It optionally accepts three parameters: A label, one math style command
 %   (\cs{displaystyle}, \cs{textstyle}, etc.) which is the implicit math style
 %   (so the style which the surrounding code expects this style to have) and a
 %   name for the root element (defaults to \texttt{mrow}).
 %   If the root element name is \texttt{mrow}, it will get suppressed in some
 %   cases.
 %    \begin{macrocode}
-\cs_new_protected:Npn \luamml_flag_save:n #1 {
+\cs_new_protected:Npn \luamml_save:n #1 {
   \tl_set:Nn \l__luamml_label_tl {#1}
   \int_set:Nn \l__luamml_flag_int { \__luamml_maybe_structelem: 1 }
 }
-\cs_new_protected:Npn \luamml_flag_save:nN #1#2 {
+\cs_new_protected:Npn \luamml_save:nN #1#2 {
   \tl_set:Nn \l__luamml_label_tl {#1}
   \int_set:Nn \l__luamml_flag_int { \__luamml_maybe_structelem: 17 + \__luamml_style_to_num:N #2 }
 }
-\cs_new_protected:Npn \luamml_flag_save:nn #1 {
+\cs_new_protected:Npn \luamml_save:nn #1 {
   \tl_set:Nn \l__luamml_label_tl {#1}
   \int_set:Nn \l__luamml_flag_int { \__luamml_maybe_structelem: 5 }
   \tl_set:Nn \l__luamml_root_tl
 }
-\cs_new_protected:Npn \luamml_flag_save:nNn #1#2 {
+\cs_new_protected:Npn \luamml_save:nNn #1#2 {
   \tl_set:Nn \l__luamml_label_tl {#1}
   \int_set:Nn \l__luamml_flag_int { \__luamml_maybe_structelem: 21 + \__luamml_style_to_num:N #2 }
   \tl_set:Nn \l__luamml_root_tl
 }
 %    \end{macrocode}
-% \end{macro}
-%
-% \begin{macro}{\luamml_flag_ignore:}
-%   Completely ignore the math mode material.
+% Temporarly for compatibility
 %    \begin{macrocode}
-\cs_new_protected:Npn \luamml_flag_ignore: {
-  \int_set:Nn \l__luamml_flag_int { 0 }
-}
+\cs_set_eq:NN \luamml_flag_save:n \luamml_save:n
+\cs_set_eq:NN \luamml_flag_save:nN \luamml_save:nN
+\cs_set_eq:NN \luamml_flag_save:nn \luamml_save:nn
+\cs_set_eq:NN \luamml_flag_save:nNn \luamml_save:nNn
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\luamml_flag_structelem:}
-%   Like \cs{luamml_flag_process:}, but additionally add PDF structure
+% \begin{macro}{\luamml_ignore:}
+%   Completely ignore the math mode material.
+%    \begin{macrocode}
+\cs_new_protected:Npn \luamml_ignore: {
+  \int_set:Nn \l__luamml_flag_int { 0 }
+}
+%    \end{macrocode}
+% Temporarly for compatibility
+%    \begin{macrocode}
+\cs_set_eq:NN \luamml_flag_ignore: \luamml_ignore:
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\luamml_structelem:}
+%   Like \cs{luamml_process:}, but additionally adds PDF structure
 %   elements. This only works in Lua\TeX\ and requires that the \pkg{tagpdf} package
 %   has been loaded \emph{before} \texttt{luamml}.
 %    \begin{macrocode}
 %<*luatex>
-\cs_new_protected:Npn \luamml_flag_structelem: {
+\cs_new_protected:Npn \luamml_structelem: {
   \tl_set:Nn \l__luamml_label_tl {}
   \int_set:Nn \l__luamml_flag_int { 11 }
 }
+%    \end{macrocode}
+% Temporarly for compatibility
+%    \begin{macrocode}
+\cs_set_eq:NN \luamml_flag_structelem: \luamml_structelem:
 %</luatex>
 %    \end{macrocode}
 % \end{macro}
@@ -282,7 +302,7 @@
 %   The value is fully expanded when the file is written.
 %   
 %   Only complete formulas get written into files (so formulas where
-%   \cs{luamml_flag_process:} or \cs{luamml_flag_structelem:} are in effect).
+%   \cs{luamml_process:} or \cs{luamml_structelem:} are in effect).
 %
 %   Only implemented in Lua\TeX, in pdf\TeX\ the arguments for \texttt{pdfmml}
 %   determine the output location.
@@ -304,7 +324,7 @@
 %
 % By default, the flag is set to assume complete formulas.
 %    \begin{macrocode}
-\luamml_flag_process:
+\luamml_process:
 %    \end{macrocode}
 %
 % \subsection{Annotations}
@@ -321,7 +341,7 @@
 % let Lua\TeX determine the number itself.
 %
 % Passing the first parameter explicitly is useful for any annotations which
-% should be compatible with fututre pdf\TeX versions of this functionality.
+% should be compatible with future pdf\TeX versions of this functionality.
 %    \begin{macrocode}
 \cs_new_protected:Npn \luamml_annotate:nen #1#2#3 {
   \__luamml_annotate_begin:


### PR DESCRIPTION
This renames (some) of the commands as discussed in the workshop. The older commands are still there for compability.

I also added the patch for mathtools from https://github.com/latex3/tagging-project/issues/734.

hyperref + \smash looks fine now, and a release would be good so that we can adjust the latex-lab math code.