### PR TITLE
fix call of debug code (kind is nil in smallmatrix function)

### DIFF
--- a/luamml-amsmath.lua
+++ b/luamml-amsmath.lua
@@ -160,7 +160,7 @@ do
       mml_table,
       {[0] = 'mspace', width = '0.167em'},
     }
-    debug_mtable(mml_table, kind)
+    debug_mtable(mml_table, 'smallmatrix')
     saved = mml_table
   end
 


### PR DESCRIPTION
a smallmatrix always wrote the table structure into the log ...